### PR TITLE
fix(dependabot): rename label uv to uv.lock

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,7 +26,7 @@ updates:
       labels:
           - "dependencies"
           - "python"
-          - "uv"
+          - "uv.lock"
       open-pull-requests-limit: 9
       schedule:
           interval: "monthly"


### PR DESCRIPTION
## Summary

- Renames the `uv` label to `uv.lock` in `dependabot.yml`
- The `uv` label did not exist in the repo, causing Dependabot to block itself from opening/labeling PRs
- The `uv.lock` label has been created in the repo

## Test plan

- [ ] Verify Dependabot no longer complains about missing labels on new PRs
- [ ] Existing open Dependabot PRs can be rebased and should auto-merge (minor/patch ones)